### PR TITLE
Exit 1 error handling for ncbi-genome-download when exit 1 is expected (for real)

### DIFF
--- a/modules/download_reference_genomes.nf
+++ b/modules/download_reference_genomes.nf
@@ -1,6 +1,10 @@
 process download_reference_genomes {
     tag "$genus"
     label 'process_single'
+    // setting errorStrategy to ignore when exit 1 is seen makes it so that 
+    // genera that don't have any matches on GenBank or RefSeq don't progress 
+    // through the pipeline, but don't stop everything else from running
+    errorStrategy { task.exitStatus == 1 ? 'ignore' : 'terminate' } 
 
     conda "$baseDir/envs/ncbi-genome-download.yml"
     //conda "bioconda::ncbi-genome-download=0.3.1"
@@ -20,6 +24,8 @@ process download_reference_genomes {
     script:
     def prefix = task.ext.prefix ?: "${genus}"
     """
+    # don't exit immediately if we get an exit 1, keep running the script.
+    set +e
     # NOTE this needs to change to accomodate bacteria or archaea inputs.
     # I'm nervous about genus collisions in the NCBI taxonomy (esp happens with viruses, i don't know if it happens between bacteria <-> euks). 
     # I could change this to go from taxid, which will be unique, harder for a user to interpret at a glance.
@@ -28,7 +34,16 @@ process download_reference_genomes {
     # genbank is separate from refseq, so run twice
     for section in genbank refseq
     do
-        ncbi-genome-download vertebrate_mammalian,vertebrate_other,invertebrate,plant,fungi,protozoa --output-folder ./ --flat-output --genera ${prefix} -F gff,cds-fasta -s \$section --retries 3
+        ncbi-genome-download vertebrate_mammalian,vertebrate_other,invertebrate,plant,fungi,protozoa --output-folder ./ --flat-output --genera ${prefix} -F gff,cds-fasta -s \$section --dry-run
+        exit_code=\$?
+        # if this gives an exit code 1 (ERROR: No downloads matched your filter. Please check your options.), skip that section as there are no outputs
+        if [ \$exit_code -eq 1 ]; then
+            echo "Skipping the next command..."
+            (exit 0) # reset exit code. failing the dry run is not problematic
+        # otherwise, do the download and get the genomes!
+        else
+            ncbi-genome-download vertebrate_mammalian,vertebrate_other,invertebrate,plant,fungi,protozoa --output-folder ./ --flat-output --genera ${prefix} -F gff,cds-fasta -s \$section --retries 3
+        fi
     done
 
     # when downloading from RefSeq and GenBank sections, there might be duplicate


### PR DESCRIPTION

ncbi genome download gives exit code1 when there are no found genomes in genbank or refseq. This causes the process to fail and to stop the pipeline from running.

This PR fixes that behavior. It:

* uses `set +e` at the top of the bash script in the process, allowing it to finish running even if there is an exit code. Typically, nextflow uses `#!/bin/bash -euo pipefail` shbang, which makes a script exit if any command has any exit code, without finished the rest of the script. `set +e` overrides this behavior.
* re-set the exit code when we fail at the expected places with exit 1. This included introducing dry-runs and other checks directly in the script
* still including `errorStrategy { task.exitStatus == 1 ? 'ignore' : 'terminate' }` at the top of the script so that when something fails for real, as it should (i.e. no genomes in genbank or refseq for a genera), the whole pipeline keeps running, but only non-dependent processes.


(note i closed #40 bc i built the branch from the wrong branch)